### PR TITLE
feat: Added QWidget

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <library path="src">
-  <class name="RqtEmbedWindow" type="rqt_embed_window.RqtEmbedWindow.RqtEmbedWindow"
+  <class name="EmbedWindow" type="rqt_embed_window.embed_window.EmbedWindow"
          base_class_type="rqt_gui_py::Plugin">
     <description>
       A GUI plugin to execute GUI applications as rqt_ plugins

--- a/scripts/rqt_embed_window
+++ b/scripts/rqt_embed_window
@@ -2,8 +2,8 @@
 
 import sys
 
-from rqt_embed_window.RqtEmbedWindow import RqtEmbedWindow
+from rqt_embed_window.embed_window import EmbedWindow
 from rqt_gui.main import Main
 
 main = Main(filename='rqt_embed_window')
-sys.exit(main.main(standalone='rqt_embed_window'))
+sys.exit(main.main(standalone='rqt_embed_window.embed_window.EmbedWindow'))

--- a/scripts/test_if_window_can_be_embedded.py
+++ b/scripts/test_if_window_can_be_embedded.py
@@ -48,8 +48,6 @@ def run_app(window_id):
 
     main_widget.show()
     app.exec_()
-    return
-    
 
 
 if __name__ == '__main__':

--- a/scripts/test_if_window_can_be_embedded.py
+++ b/scripts/test_if_window_can_be_embedded.py
@@ -48,6 +48,7 @@ def run_app(window_id):
 
     main_widget.show()
     app.exec_()
+    return
     
 
 

--- a/src/rqt_embed_window/EmbedWindow.ui
+++ b/src/rqt_embed_window/EmbedWindow.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>RqtEmbedWindowWidget</class>
- <widget class="QWidget" name="RqtEmbedWindowWidget">
+ <class>EmbedWindowWidget</class>
+ <widget class="QWidget" name="EmbedWindowWidget">
   <property name="enabled">
    <bool>true</bool>
   </property>

--- a/src/rqt_embed_window/embed_window.py
+++ b/src/rqt_embed_window/embed_window.py
@@ -24,7 +24,6 @@ class EmbedWindow(Plugin):
         context.add_widget(self._widget)
 
         self.context = context
-        return
 
     def add_external_window_widget(self):
         self._widget.add_external_window_widget(self._command, self._window_name, self._timeout_to_window_discovery)
@@ -35,17 +34,14 @@ class EmbedWindow(Plugin):
         else:
             self._widget.setWindowTitle('{} ({}) ({})'.format(self._widget.windowTitle(),
                                                               self.context.serial_number(), self._command))
-        return
 
     def shutdown_plugin(self):
         # Free resources
         self._widget.kill_process()
-        return
 
     def save_settings(self, plugin_settings, instance_settings):
         instance_settings.set_value("command", self._command)
         instance_settings.set_value("window_name", self._window_name)
-        return
 
     def restore_settings(self, plugin_settings, instance_settings):
         self._command = instance_settings.value("command")
@@ -54,7 +50,6 @@ class EmbedWindow(Plugin):
             self.add_external_window_widget()
         else:
             self.trigger_configuration()
-        return
 
     def trigger_configuration(self):
         # Enable the gear icon and allow to configure the plugin for the program to execute
@@ -80,4 +75,3 @@ class EmbedWindow(Plugin):
                 self._widget.kill_process()
 
             self.add_external_window_widget()
-        return

--- a/src/rqt_embed_window/embed_window.py
+++ b/src/rqt_embed_window/embed_window.py
@@ -1,0 +1,83 @@
+from python_qt_binding.QtWidgets import QInputDialog
+from qt_gui.plugin import Plugin
+from qt_gui.settings import Settings
+
+from .embed_window_widget import EmbedWindowWidget
+
+
+class EmbedWindow(Plugin):
+    """
+    This plugin allows to embed a Qt window into a rqt plugin.
+    """
+
+    def __init__(self, context):
+        super(EmbedWindow, self).__init__(context)
+        self.setObjectName('EmbedWindow')
+        self._command = ''
+        self._window_name = ''
+        self._process = None
+        self._timeout_to_window_discovery = 20.0
+
+        # Create widget
+        self._widget = EmbedWindowWidget()
+        # Add widget to the user interface
+        context.add_widget(self._widget)
+
+        self.context = context
+        return
+
+    def add_external_window_widget(self):
+        self._widget.add_external_window_widget(self._command, self._window_name, self._timeout_to_window_discovery)
+
+        # Give the title (for rqt_gui compositions) some information
+        if self.context.serial_number() < 2:
+            self._widget.setWindowTitle('{}      ({})'.format(self._widget.windowTitle(), self._command))
+        else:
+            self._widget.setWindowTitle('{} ({}) ({})'.format(self._widget.windowTitle(),
+                                                              self.context.serial_number(), self._command))
+        return
+
+    def shutdown_plugin(self):
+        # Free resources
+        self._widget.kill_process()
+        return
+
+    def save_settings(self, plugin_settings, instance_settings):
+        instance_settings.set_value("command", self._command)
+        instance_settings.set_value("window_name", self._window_name)
+        return
+
+    def restore_settings(self, plugin_settings, instance_settings):
+        self._command = instance_settings.value("command")
+        self._window_name = instance_settings.value("window_name")
+        if self._command is not None and self._command != '':
+            self.add_external_window_widget()
+        else:
+            self.trigger_configuration()
+        return
+
+    def trigger_configuration(self):
+        # Enable the gear icon and allow to configure the plugin for the program to execute
+        text, ok = QInputDialog.getText(self._widget, 'rqt_embed_window Settings',
+                                        "Qt GUI command to execute (disable splashscreens):",
+                                        text=self._command)
+        if ok:
+            self._command = text
+
+            # Ask if the user wants to use the Window Name instead of the PID to find the window
+            # Some apps spawn different processes and it's hard to find the window otherwise
+            text, ok = QInputDialog.getText(self._widget, 'rqt_embed_window Settings',
+                                            "If you prefer to find the window by the window name, input it here:",
+                                            text=self._window_name)
+            if ok:
+                self._window_name = text
+
+            # Refresh plugin!
+            if not self._widget.is_window_empty():
+                self._widget.remove_widget()
+
+            if self._widget.is_process_running():
+                self._widget.kill_process()
+
+            self.add_external_window_widget()
+        return

--- a/src/rqt_embed_window/embed_window_widget.py
+++ b/src/rqt_embed_window/embed_window_widget.py
@@ -29,7 +29,7 @@ def get_window_id_by_window_name(window_name):
             # Avoiding dealing with unicode...
             if str(this_window_name) == str(window_name):
                 return int(fields[0], 16)
-    return
+    return None
 
 
 def get_window_id_by_pid(pid):
@@ -51,7 +51,7 @@ def get_window_id_by_pid(pid):
             this_pid = int(fields[2])
             if this_pid == pid:
                 return int(fields[0], 16)
-    return
+    return None
 
 
 def wait_for_window_id(pid=None, window_name=None, timeout=5.0):
@@ -92,7 +92,6 @@ class EmbedWindowWidget(QWidget):
         # Extend the widget with all attributes and children from UI file
         loadUi(ui_file, self)
         self.setObjectName('EmbedWindowUi')
-        return
 
     def add_external_window_widget(self, command, window_name = "", timeout_to_window_discovery = 20.0):
         # The command is prepended with exec so it becomes the shell executing it
@@ -115,7 +114,7 @@ class EmbedWindowWidget(QWidget):
                                                                                                           self._process.get_stdout(),
                                                                                                           self._process.get_stderr()))
             self._process.kill()
-            return
+            return None
 
         # Create a the window that will contain the program
         window = QWindow.fromWinId(window_id)
@@ -132,18 +131,17 @@ class EmbedWindowWidget(QWidget):
 
         self.verticalLayout.addWidget(self._external_window_widget)
 
-        return
-    
+        return None
+
     def is_window_empty(self):
         return (self._external_window_widget is None)
 
     def remove_widget(self):
         self.verticalLayout.removeWidget(self._external_window_widget)
-        return
 
     def is_process_running(self):
         return (self._process is not None and not self._process.is_done())
     
     def kill_process(self):
-        self._process.kill()
-        return
+        if self._process:
+            self._process.kill()

--- a/src/rqt_embed_window/embed_window_widget.py
+++ b/src/rqt_embed_window/embed_window_widget.py
@@ -2,12 +2,10 @@ import os
 import rospy
 import time
 
-from qt_gui.plugin import Plugin
 from python_qt_binding import loadUi
-from python_qt_binding.QtWidgets import QWidget, QInputDialog
+from python_qt_binding.QtWidgets import QWidget
 from python_qt_binding.QtGui import QWindow
 from python_qt_binding.QtCore import Qt
-from qt_gui.settings import Settings
 from shell_cmd import ShellCmd
 
 
@@ -31,7 +29,7 @@ def get_window_id_by_window_name(window_name):
             # Avoiding dealing with unicode...
             if str(this_window_name) == str(window_name):
                 return int(fields[0], 16)
-    return None
+    return
 
 
 def get_window_id_by_pid(pid):
@@ -53,7 +51,7 @@ def get_window_id_by_pid(pid):
             this_pid = int(fields[2])
             if this_pid == pid:
                 return int(fields[0], 16)
-    return None
+    return
 
 
 def wait_for_window_id(pid=None, window_name=None, timeout=5.0):
@@ -75,52 +73,45 @@ def wait_for_window_id(pid=None, window_name=None, timeout=5.0):
     return window_id
 
 
-class RqtEmbedWindow(Plugin):
+class EmbedWindowWidget(QWidget):
     """
-    This plugin allows to embed a Qt window into a rqt plugin.
+    Separated QWidget from plugin
     """
 
-    def __init__(self, context):
-        super(RqtEmbedWindow, self).__init__(context)
-        self.setObjectName('RqtEmbedWindow')
-        self._command = ''
-        self._window_name = ''
+    def __init__(self, plugin = None):
+        super(EmbedWindowWidget, self).__init__()
         self._external_window_widget = None
         self._process = None
-        self._timeout_to_window_discovery = 20.0
+        self._plugin = plugin
 
         # Create QWidget
-        self._widget = QWidget()
         # Get path to UI file which is a sibling of this file
         # in this example the .ui and .py file are in the same folder
         ui_file = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                               'RqtEmbedWindow.ui')
+                               'EmbedWindow.ui')
         # Extend the widget with all attributes and children from UI file
-        loadUi(ui_file, self._widget)
-        self._widget.setObjectName('RqtEmbedWindowUi')
-        # Add widget to the user interface
-        context.add_widget(self._widget)
+        loadUi(ui_file, self)
+        self.setObjectName('EmbedWindowUi')
+        return
 
-        self.context = context
-
-    def add_external_window_widget(self):
+    def add_external_window_widget(self, command, window_name = "", timeout_to_window_discovery = 20.0):
         # The command is prepended with exec so it becomes the shell executing it
         # So it effectively has the PID we will look for the window ID
-        self._process = ShellCmd("exec " + self._command)
+        self._process = ShellCmd("exec " + command)
 
         # If a window name is provided, it probably means that's the only way to find the window
         # so, let's do that first
-        if self._window_name:
-            window_id = wait_for_window_id(window_name=self._window_name,
-                                           timeout=self._timeout_to_window_discovery)
+        if window_name:
+            window_id = wait_for_window_id(window_name=window_name,
+                                           timeout=timeout_to_window_discovery)
         else:
             # Get window ID from PID, we must wait for it to appear
             window_id = wait_for_window_id(pid=self._process.get_pid(),
-                                           timeout=self._timeout_to_window_discovery)
+                                           timeout=timeout_to_window_discovery)
         if window_id is None:
             rospy.logerr("Could not find window id...")
-            rospy.logerr("Command was: {} \nWindow name was: '{}'\nStdOut was: {}\nStdErr was: {}".format(self._command,
-                                                                                                          self._window_name,
+            rospy.logerr("Command was: {} \nWindow name was: '{}'\nStdOut was: {}\nStdErr was: {}".format(command,
+                                                                                                          window_name,
                                                                                                           self._process.get_stdout(),
                                                                                                           self._process.get_stderr()))
             self._process.kill()
@@ -136,55 +127,23 @@ class RqtEmbedWindow(Plugin):
         self._external_window_widget = widget
 
         # Set all margins and spacing to 0 to maximize window usage
-        self._widget.verticalLayout.setContentsMargins(0, 0, 0, 0)
-        self._widget.verticalLayout.setSpacing(0)
+        self.verticalLayout.setContentsMargins(0, 0, 0, 0)
+        self.verticalLayout.setSpacing(0)
 
-        self._widget.verticalLayout.addWidget(self._external_window_widget)
+        self.verticalLayout.addWidget(self._external_window_widget)
 
-        # Give the title (for rqt_gui compisitions) some information
-        if self.context.serial_number() < 2:
-            self._widget.setWindowTitle('{}      ({})'.format(self._widget.windowTitle(), self._command))
-        else:
-            self._widget.setWindowTitle('{} ({}) ({})'.format(self._widget.windowTitle(),
-                                                              self.context.serial_number(), self._command))
+        return
+    
+    def is_window_empty(self):
+        return (self._external_window_widget is None)
 
-    def shutdown_plugin(self):
-        # Free resources
+    def remove_widget(self):
+        self.verticalLayout.removeWidget(self._external_window_widget)
+        return
+
+    def is_process_running(self):
+        return (self._process is not None and not self._process.is_done())
+    
+    def kill_process(self):
         self._process.kill()
-
-    def save_settings(self, plugin_settings, instance_settings):
-        instance_settings.set_value("command", self._command)
-        instance_settings.set_value("window_name", self._window_name)
-
-    def restore_settings(self, plugin_settings, instance_settings):
-        self._command = instance_settings.value("command")
-        self._window_name = instance_settings.value("window_name")
-        if self._command is not None and self._command != '':
-            self.add_external_window_widget()
-        else:
-            self.trigger_configuration()
-
-    def trigger_configuration(self):
-        # Enable the gear icon and allow to configure the plugin for the program to execute
-        text, ok = QInputDialog.getText(self._widget, 'RqtEmbedWindow Settings',
-                                        "Qt GUI command to execute (disable splashscreens):",
-                                        text=self._command)
-        if ok:
-            self._command = text
-
-            # Ask if the user wants to use the Window Name instead of the PID to find the window
-            # Some apps spawn different processes and it's hard to find the window otherwise
-            text, ok = QInputDialog.getText(self._widget, 'RqtEmbedWindow Settings',
-                                            "If you prefer to find the window by the window name, input it here:",
-                                            text=self._window_name)
-            if ok:
-                self._window_name = text
-
-            # Refresh plugin!
-            if self._external_window_widget is not None:
-                self._widget.verticalLayout.removeWidget(self._external_window_widget)
-
-            if self._process is not None and not self._process.is_done():
-                self._process.kill()
-
-            self.add_external_window_widget()
+        return

--- a/src/rqt_embed_window/shell_cmd.py
+++ b/src/rqt_embed_window/shell_cmd.py
@@ -18,6 +18,7 @@ class ShellCmd:
         self.process = subprocess.Popen(cmd, shell=True, stdin=self.inf,
                                         stdout=self.outf, stderr=self.errf,
                                         preexec_fn=os.setsid, close_fds=True)
+        return;
 
     def __del__(self):
         if not self.is_done():
@@ -25,6 +26,7 @@ class ShellCmd:
         self.outf.close()
         self.errf.close()
         self.inf.close()
+        return;
 
     def get_stdout(self):
         with open(self.outf.name, "r") as f:
@@ -51,6 +53,7 @@ class ShellCmd:
     def wait_until_done(self):
         while not self.is_done():
             time.sleep(0.1)
+        return;
 
 
     def get_pid(self):
@@ -60,6 +63,7 @@ class ShellCmd:
         self.retcode = -1
         os.killpg(self.process.pid, signal.SIGTERM)
         self.process.wait()
+        return;
 
 
 # Demonstration of usage

--- a/src/rqt_embed_window/shell_cmd.py
+++ b/src/rqt_embed_window/shell_cmd.py
@@ -18,7 +18,6 @@ class ShellCmd:
         self.process = subprocess.Popen(cmd, shell=True, stdin=self.inf,
                                         stdout=self.outf, stderr=self.errf,
                                         preexec_fn=os.setsid, close_fds=True)
-        return;
 
     def __del__(self):
         if not self.is_done():
@@ -26,7 +25,6 @@ class ShellCmd:
         self.outf.close()
         self.errf.close()
         self.inf.close()
-        return;
 
     def get_stdout(self):
         with open(self.outf.name, "r") as f:
@@ -53,8 +51,6 @@ class ShellCmd:
     def wait_until_done(self):
         while not self.is_done():
             time.sleep(0.1)
-        return;
-
 
     def get_pid(self):
         return self.process.pid
@@ -63,7 +59,6 @@ class ShellCmd:
         self.retcode = -1
         os.killpg(self.process.pid, signal.SIGTERM)
         self.process.wait()
-        return;
 
 
 # Demonstration of usage


### PR DESCRIPTION
The disadvantage of the current code is that the widget itself is directly implemented  in the plugin. This way somebody can't embed the GUI into his/her own GUI easily (like in this tutorial [here](http://wiki.ros.org/rqt/Tutorials/Using%20.ui%20file%20in%20rqt%20plugin#Reusing_existing_GUI_class)). Therefore I have 
- **Separated the `Plugin` and the `QWidget`** (just like most of the other `rqt` packages do)
- Renamed the **files** in a similar fashion to the other packages with **underscores** instead of camelcased filenames.

I made a simple example of how this can be useful [here](https://github.com/2b-t/rqt_embed_window_example) (also see image below). Furthermore this somehow seems to solves the issue pointed out in #2.

![Screenshot](https://user-images.githubusercontent.com/53856473/123483960-e16c0500-d607-11eb-91f4-9d03cee64ca7.png)
